### PR TITLE
ci: bump version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,32 @@
+name: bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.6"
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+          fetch-depth: 0
+
+      - name: Create bump and changelog
+        id: cz
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.TOKEN }}
+
+      - name: Print version
+        run: echo "Bumped to version ${{ steps.cz.outputs.version }}"


### PR DESCRIPTION
When a commit is pushed on main,
we bump the version, create a changelog and push tag. It uses commitizen